### PR TITLE
add couchdb restart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up CouchDB
-      uses: cobot/couchdb-action@master
+      uses: .
       with:
         couchdb version: '2.3.1'
         erlang query server: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       uses: ./
       with:
         couchdb version: '2.3.1'
-        erlang query server: true
     - name: Test that CouchDB can be accessed
       run: curl -sS -f http://127.0.0.1:5984/
     - name: Test that system databases are there

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up CouchDB
-      uses: .
+      uses: ./
       with:
         couchdb version: '2.3.1'
         erlang query server: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CouchDB GitHub Action
 
 This [GitHub Action](https://github.com/features/actions) sets up a CouchDB database.
+The Erlang query server is enabled.
 
 # Usage
 
@@ -13,7 +14,6 @@ steps:
     uses: "cobot/couchdb-action@master"
     with:
       couchdb version: '2.3.1'
-      erlang query server: true|false
   - name: Do something
     run: |
       curl http://127.0.0.1:5984/

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,6 @@ inputs:
     description: 'Version of CouchDB to use.'
     required: false
     default: 'latest'
-  erlang query server:
-    description: 'Enable Erlang query server.'
-    required: false
-    default: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,26 +6,7 @@ sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk couchdb:$INPUT_
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`
 
-# Enable delayed commits for better performance
-echo "Enabling delayed commits..."
-docker exec $NAME mkdir -p /opt/couchdb/etc/local.d
-docker exec $NAME sh -c 'echo "[couchdb]\ndelayed_commits = true" >> /opt/couchdb/etc/local.d/01-delayed-commits.ini'
-
-echo "Setting nodelay option"
-docker exec $NAME sh -c 'echo "[httpd]\nsocket_options = [{nodelay, true}]" >> /opt/couchdb/etc/local.d/02-performance.ini'
-
-echo "Configuring CouchDB to use RAM disk"
-docker exec $NAME sh -c 'echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk" >> /opt/couchdb/etc/local.d/03-ram-disk.ini'
-
-# Enable Erlang query server
-if [ "$INPUT_ERLANG_QUERY_SERVER" = 'true' ]
-then
-  echo "Enabling Erlang query server..."
-  docker exec $NAME sh -c 'echo "[native_query_servers]\nerlang = {couch_native_process, start_link, []}" >> /opt/couchdb/etc/local.d/15-erlang-query-server.ini'
-fi
-
-echo "Restarting CouchDB..."
-docker exec $NAME /etc/init.d/couchdb restart
+docker exec $NAME mkdir -p /opt/couchdb/etc/local.d && sh -c 'echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nerlang = {couch_native_process, start_link, []}" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini'
 
 wait_for_couchdb() {
   echo "Waiting for CouchDB..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,9 @@ then
   docker exec $NAME sh -c 'echo "[native_query_servers]\nerlang = {couch_native_process, start_link, []}" >> /opt/couchdb/etc/local.d/15-erlang-query-server.ini'
 fi
 
+echo "Restarting CouchDB..."
+docker exec $NAME /etc/init.d/couchdb restart
+
 wait_for_couchdb() {
   echo "Waiting for CouchDB..."
   hostip=$(ip route show | awk '/default/ {print $3}')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk couchdb:$INPUT_
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`
 
-docker exec $NAME mkdir -p /opt/couchdb/etc/local.d && sh -c 'echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nerlang = {couch_native_process, start_link, []}" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini'
+docker exec $NAME sh -c 'mkdir -p /opt/couchdb/etc/local.d && echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nerlang = {couch_native_process, start_link, []}" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini'
 
 wait_for_couchdb() {
   echo "Waiting for CouchDB..."


### PR DESCRIPTION
to fix problem where sometimes erlang query server is not enabled because
config file was written after couchdb had already started.