### PR TITLE
Add support for admin user creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,29 @@ on:
     branches:
     - master
 jobs:
-  tests:
+  tests-with-admin:
+    env:
+     COUCHDB_USER: couchdb
+     COUCHDB_PASSWORD: admin
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up CouchDB
+      uses: ./
+      with:
+        couchdb version: '3.2.1'
+    - name: Test that CouchDB can be accessed
+      run: curl -sS -f http://127.0.0.1:5984/
+    - name: Test admin credentials
+      run: curl -sS -f -u $COUCHDB_USER:$COUCHDB_PASSWORD http://127.0.0.1:5984/_session
+    - name: Test that system databases are there
+      run: curl -sS -f -u $COUCHDB_USER:$COUCHDB_PASSWORD http://127.0.0.1:5984/_users
+    - name: Test that the Erlang query server is enabled
+      run: |
+        curl -sS -f -u $COUCHDB_USER:$COUCHDB_PASSWORD 'http://127.0.0.1:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
+        curl -sS -f -u $COUCHDB_USER:$COUCHDB_PASSWORD 'http://127.0.0.1:5984/_users/_design/test/_view/test'
+   
+  tests-with-admin-party:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
 
+CFG_COUCHDB_ADMIN="" 
+CURL_CREDENTIALS=""
+
+if [[ -z "$COUCHDB_USER" ]] || [[ -z "$COUCHDB_PASSWORD" ]]; then
+ echo ">> COUCHDB admin credentials not defined - ADMIN PARTY is not supported on 3.x"
+else
+ echo ">> COUCHDB admin credentials provided"
+ CFG_COUCHDB_ADMIN="-e COUCHDB_USER=$COUCHDB_USER -e COUCHDB_PASSWORD=$COUCHDB_PASSWORD"
+ CURL_CREDENTIALS="-u $COUCHDB_USER:$COUCHDB_PASSWORD"
+fi
+
 echo "Starting Docker..."
-sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
+sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk $CFG_COUCHDB_ADMIN couchdb:$INPUT_COUCHDB_VERSION"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`
@@ -22,6 +33,6 @@ wait_for_couchdb
 
 # Set up system databases
 echo "Setting up CouchDB system databases..."
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_users' -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_global_changes' -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_replicator' -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null
+docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_users' -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
+docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_global_changes' -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
+docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_replicator' -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null


### PR DESCRIPTION
Since 3.x version admin party is not supported, this PR adds support for admin credentials definition. 

COUCHDB_USER and COUCHDB_PASSWORD env variables are propagated to the CouchDB container and used on the system dbs creation script. 

Thanks!