### PR TITLE
feat: Add admin credentials input for CouchDB v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   couchdb password:
     description: 'Password of the admin user.'
     required: false
+outputs:
+  couchdb-url:
+    description: 'Base URL to make requests to CouchDB.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,12 @@ inputs:
     description: 'Version of CouchDB to use.'
     required: false
     default: 'latest'
+  couchdb user:
+    description: 'Username name of the admin user.'
+    required: false
+  couchdb password:
+    description: 'Password of the admin user.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 
+if [[ -z "$INPUT_COUCHDB_USER" ]] || [[ -z "$INPUT_COUCHDB_PASSWORD" ]]; then
+  echo ">> CouchDB admin credentials not defined - ADMIN PARTY is not supported on 3.x"
+else
+  echo ">> CouchDB admin credentials provided"
+  CFG_COUCHDB_ADMIN="-e COUCHDB_USER=$INPUT_COUCHDB_USER -e COUCHDB_PASSWORD=$INPUT_COUCHDB_PASSWORD"
+  CURL_CREDENTIALS="-u $INPUT_COUCHDB_USER:$INPUT_COUCHDB_PASSWORD"
+fi
+
 echo "Starting Docker..."
-sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
+sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk $CFG_COUCHDB_ADMIN couchdb:$INPUT_COUCHDB_VERSION"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`
@@ -22,6 +30,6 @@ wait_for_couchdb
 
 # Set up system databases
 echo "Setting up CouchDB system databases..."
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_users' -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_global_changes' -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_replicator' -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null
+docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_users' -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
+docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_global_changes' -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
+docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_replicator' -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,3 +33,6 @@ echo "Setting up CouchDB system databases..."
 docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_users' -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
 docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_global_changes' -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
 docker exec $NAME curl -sS $CURL_CREDENTIALS 'http://127.0.0.1:5984/_replicator' -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null
+
+COUCHDB_URL="http://$INPUT_COUCHDB_USER:$INPUT_COUCHDB_PASSWORD@127.0.0.1:5984/"
+echo "couchdb-url=$(echo $COUCHDB_URL)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
CouchDB v3 requires an admin user to start. The Docker image will
create that user automatically if the credentials are passed as
arguments.

These credentials can then be used in requests to CouchDB.

This is based on #9 by @jjrodrig but using action inputs rather than env variables.